### PR TITLE
Resolve typo on  function `getMessage` -> change by `getMessageEnvelope`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $redisClient = new PredisClient(); // refer to PredisDocumentation
 $queue = new RedisMessageBroker\Queue\Definition('raoul');
 $consumer = new RedisMessageBroker\MessageHandler\Consumer($queue, $redisClient, uniqid());
 
-$message = $consumer->getMessage();
+$message = $consumer->getMessageEnvelope();
 
 ```
 
@@ -104,7 +104,7 @@ $queue = new RedisMessageBroker\Queue\Definition('raoul');
 $consumer = new RedisMessageBroker\MessageHandler\Consumer($queue, $redisClient, uniqid());
 $consumer->setNoAutoAck();
 
-$message = $consumer->getMessage();
+$message = $consumer->getMessageEnvelope();
 if ($message) {
     // do something with the message
     $consumer->ack($message); // erase the message from the working list

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "predis/predis": "^1.1.1"
   },
   "require-dev": {
-    "m6web/php-cs-fixer-config": "0.2.0",
+    "m6web/php-cs-fixer-config": "^1.0",
     "atoum/atoum": "~3.0.0"
   },
   "autoload": {

--- a/src/MessageEnvelope.php
+++ b/src/MessageEnvelope.php
@@ -55,7 +55,7 @@ class MessageEnvelope
         return $this->id;
     }
 
-    public function setUpdatedAt(\DateTime $dateTime): MessageEnvelope
+    public function setUpdatedAt(\DateTime $dateTime): self
     {
         $this->createdAt = $dateTime;
 
@@ -74,7 +74,7 @@ class MessageEnvelope
 
     public function incrementRetry()
     {
-        ++$this->retry;
+        $this->retry++;
 
         return $this;
     }
@@ -94,7 +94,7 @@ class MessageEnvelope
         return serialize($this);
     }
 
-    public static function unserializeMessage(string $message): ?MessageEnvelope
+    public static function unserializeMessage(string $message): ?self
     {
         $unserializeMessage = unserialize($message);
 

--- a/src/MessageHandler/LostMessagesConsumer.php
+++ b/src/MessageHandler/LostMessagesConsumer.php
@@ -55,7 +55,7 @@ class LostMessagesConsumer extends AbstractMessageHandler
 
     protected function requeueOldMessageFromList(string $list)
     {
-        for ($i = 0, $n = $this->redisClient->llen($list); $i < $n; ++$i) {
+        for ($i = 0, $n = $this->redisClient->llen($list); $i < $n; $i++) {
             $serializedMessage = $this->redisClient->rpoplpush($list, $list);
 
             // check if message is old enough

--- a/src/Queue/Cleanup.php
+++ b/src/Queue/Cleanup.php
@@ -62,7 +62,7 @@ class Cleanup extends AbstractQueueTool
         $r = 0;
         foreach ($lists as $list) {
             $listLen = $this->redisClient->llen($list);
-            for ($i = 1; $i <= $listLen; ++$i) {
+            for ($i = 1; $i <= $listLen; $i++) {
                 $message = $this->redisClient->rpoplpush($list, $list);
                 if ($hasToDelete(MessageEnvelope::unserializeMessage($message))) {
                     $r += $this->redisClient->lrem($list, 0, $message);

--- a/tests/MessageHandler/Consumer.php
+++ b/tests/MessageHandler/Consumer.php
@@ -26,7 +26,7 @@ class Consumer extends atoum\test
             )
             ->then
                 // get the message produced and see if its the same
-                ->object($newMessage = $consumer->getMessage())
+                ->object($newMessage = $consumer->getMessageEnvelope())
             ->and
                 ->string($newMessage->getMessage())
                 ->isIdenticalTo($message->getMessage())
@@ -55,7 +55,7 @@ class Consumer extends atoum\test
                 $inspector = new Inspector($queue, $redisClient)
             )
             ->then
-                ->object($newMessage = $consumer->getMessage())
+                ->object($newMessage = $consumer->getMessageEnvelope())
             ->and
                 // message should not be in the queue but in the working list
                 ->integer($inspector->countReadyMessages())
@@ -74,7 +74,7 @@ class Consumer extends atoum\test
 
         $this
             ->if($producer->publishMessage($message))
-            ->and($newMessage = $consumer->getMessage())
+            ->and($newMessage = $consumer->getMessageEnvelope())
             ->then(
                 // a new consumer should NOT be able to get the message even if is not acked
                 $consumer2 = $this->newTestedInstance($queue, $redisClient, 'testConsumer2'.uniqid('test_redis', false)),
@@ -106,8 +106,8 @@ class Consumer extends atoum\test
                 $inspector = new Inspector($queue, $redisClient)
             )
             ->then
-                ->object($consumer->getMessage())
-                ->object($consumer->getMessage())
+                ->object($consumer->getMessageEnvelope())
+                ->object($consumer->getMessageEnvelope())
 
                 // messages should not be in the queue but in the working list
                 ->integer($inspector->countReadyMessages())
@@ -141,7 +141,7 @@ class Consumer extends atoum\test
                 $inspector = new Inspector($queue, $redisClient)
             )
             ->then
-                ->object($message = $consumer->getMessage())
+                ->object($message = $consumer->getMessageEnvelope())
 
                 // messages should not be in the queue but in the working list
                 ->integer($inspector->countReadyMessages())
@@ -177,8 +177,8 @@ class Consumer extends atoum\test
                 $inspector = new Inspector($queue, $redisClient)
             )
             ->then
-                ->object($consumer->getMessage())
-                ->object($consumer->getMessage())
+                ->object($consumer->getMessageEnvelope())
+                ->object($consumer->getMessageEnvelope())
 
                 // messages should not be in the queue but in the working list
                 ->integer($inspector->countReadyMessages())
@@ -215,7 +215,7 @@ class Consumer extends atoum\test
             ->if(
                 $consumer = $this->newTestedInstance($queue, $redisClient, 'testConsumer3'.uniqid('test_redis', false)),
                 $consumer->setNoAutoAck(),
-                $message = $consumer->getMessage()
+                $message = $consumer->getMessageEnvelope()
             )
             ->then
                 ->integer($inspector->countListQueues())

--- a/tests/MessageHandler/LostMessagesConsumer.php
+++ b/tests/MessageHandler/LostMessagesConsumer.php
@@ -26,7 +26,7 @@ class LostMessagesConsumer extends atoum\test
 
                 $consumer = new Consumer($queue, $redisClient, 'testConsumer2'.uniqid('test_redis', false)),
                 $consumer->setNoAutoAck(),
-                $consumer->getMessage()
+                $consumer->getMessageEnvelope()
             )
             ->then(
                 sleep(10), // build an 20s old message
@@ -66,7 +66,7 @@ class LostMessagesConsumer extends atoum\test
 
                 $consumer = new Consumer($queue, $redisClient, 'testConsumer2'.uniqid('test_redis', false)),
                 $consumer->setNoAutoAck(),
-                $consumer->getMessage()
+                $consumer->getMessageEnvelope()
             )
             ->then(
                 sleep(2), // build an 2s old message, retry set to 1

--- a/tests/Queue/Cleanup.php
+++ b/tests/Queue/Cleanup.php
@@ -57,7 +57,7 @@ class Cleanup extends atoum\test
                 $consumer->setNoAutoAck()
             )
             ->and(
-                $consumer->getMessage(), // get one message
+                $consumer->getMessageEnvelope(), // get one message
                 sleep(4) // build two 4s old message
             )
             ->and
@@ -85,7 +85,7 @@ class Cleanup extends atoum\test
 
                 $consumer = new Consumer($queue, $redisClient, 'testConsumer2'.uniqid('test_redis', false)),
                 $consumer->setNoAutoAck(),
-                $consumer->getMessage(),
+                $consumer->getMessageEnvelope(),
 
 
                 sleep(2),


### PR DESCRIPTION
Edit the name of function return a `MessageEnvelope` : `$consumer->getMessage()` to `$consumer->getMessageEnvelope()` 

It's make more sense when we get a `$consumer->getMessageEnvelope()->getMessage()`.