### PR TITLE
Fix increment retry Message from Unack method

### DIFF
--- a/src/MessageEnvelope.php
+++ b/src/MessageEnvelope.php
@@ -72,8 +72,10 @@ class MessageEnvelope
         return $this->updatedAt;
     }
 
-    public function incrementRetry()
+    public function incrementRetry(): self
     {
+        $this->setUpdatedAt(new \DateTime());
+
         $this->retry++;
 
         return $this;

--- a/src/MessageHandler/LostMessagesConsumer.php
+++ b/src/MessageHandler/LostMessagesConsumer.php
@@ -85,7 +85,6 @@ class LostMessagesConsumer extends AbstractMessageHandler
 
     protected function addMessageInQueueList(MessageEnvelope $message)
     {
-        $message->setUpdatedAt(new \DateTime());
         $message->incrementRetry();
 
         $list = $this->queue->getARandomListName();

--- a/tests/MessageHandler/Consumer.php
+++ b/tests/MessageHandler/Consumer.php
@@ -186,7 +186,7 @@ class Consumer extends atoum\test
                 ->integer($inspector->countInProgressMessages())
                 ->isEqualTo(2)
             ->and
-                // ack messages
+                // unack messages
                 ->integer($consumer->unackAll())
                 // messages is gone
                 ->integer($inspector->countReadyMessages())


### PR DESCRIPTION
Fix retry increment when message is unack.

In the case of the message is unack, we want to increment the retry number. 