### PR TITLE
Add getValue() method for add .gauge type with StatsDBundle

### DIFF
--- a/src/Event/ConsumerEvent.php
+++ b/src/Event/ConsumerEvent.php
@@ -47,4 +47,9 @@ class ConsumerEvent
     {
         return $this->listName;
     }
+
+    public function getValue(): int
+    {
+        return $this->nbMessage;
+    }
 }


### PR DESCRIPTION
To use correctly the `StatsDBundle` with the `RedisMessageBroker`, and for lisibility in `statsd.yml`, I add a 'getValue()' method in ConsumerEvent. 