### PR TITLE
Force uniqueId generation if uniquId is null

### DIFF
--- a/src/MessageHandler/LostMessagesConsumer.php
+++ b/src/MessageHandler/LostMessagesConsumer.php
@@ -87,11 +87,11 @@ class LostMessagesConsumer extends AbstractMessageHandler
     {
         $message->incrementRetry();
 
-        $list = $this->queue->getARandomListName();
-        $this->redisClient->lpush($list, $message->getSerializedValue());
+        $queueName = $this->queue->getARandomListName();
+        $this->redisClient->lpush($queueName, $message->getSerializedValue());
 
         if ($this->eventCallback) {
-            ($this->eventCallback)(new ConsumerEvent(ConsumerEvent::REQUEUE_OLD_MESSAGE, 1, $list));
+            ($this->eventCallback)(new ConsumerEvent(ConsumerEvent::REQUEUE_OLD_MESSAGE, 1, $queueName));
         }
     }
 }

--- a/tests/MessageHandler/Consumer.php
+++ b/tests/MessageHandler/Consumer.php
@@ -249,10 +249,10 @@ class Consumer extends atoum\test
                 $consumer = $this->newTestedInstance($queue, $redisClient, 'testConsumer1'.uniqid('test_redis', false))
             )
             ->then
-                ->array($queueListName = $consumer->getQueueListsLength())
+                ->array($queueListLength = $consumer->getQueueListsLength())
                     ->hasSize(1)
                     ->hasKey($queueName.'_list__1')
-                ->integer($queueListName[$queueName.'_list__1'])
+                ->integer($queueListLength[$queueName.'_list__1'])
                     ->isEqualTo(2)
         ;
     }


### PR DESCRIPTION
Because we want to use Unack, and get a true random working list with UniquID without Symfony cache, and rename vars...